### PR TITLE
Feature ETP-1620: Improve steps order and links

### DIFF
--- a/docs/user-guide/etendo-classic/basic-features/production-management/getting-started.md
+++ b/docs/user-guide/etendo-classic/basic-features/production-management/getting-started.md
@@ -17,88 +17,94 @@ tags:
 
 The Production Management module allows managing the standard productive process: production plan, work requirement, end products report and its direct and indirect costs. It is also possible to manage quality control and machine maintenance in production.
 
-## Production Management
-
 The main documents to manage the production process are:
 
-- the Process Plan
-- the Work Requirement
-- the Work Effort
+- [Process Plan](./setup.md#process-plan)
+- [Work Requirement](./transactions.md#work-requirement)
+- [Work Effort](./transactions.md#work-effort)
+
+!!! tip
+    It is important to be clear about these concepts and windows before reading on. 
+
 
 ![](../../../../assets/drive/1lCJc82jrHhfKt3KS2Eg9SS0aoPpYMsD7.png)
 
-#### **Configuration**
+## Initial Configuration
 
-Apart from the setup screens in the Production module, additional setups are required.
+Apart from the [setup windows](./setup.md) in the Production module, additional setups are required.
 
-For Production, there are different products that are set up:
+1. For Production, there are different products that are set up:
 
-- Raw material used in production
-  - the Production checkbox is selected to indicate that the product is used for production
-  - the process plan is selected
-  - the default storage bin that is used for P- raw materials is defined in the [_Manufacturing_](../master-data-management/master-data.md#product) tab.
-- Finished products manufactured in production
-  - the Production checkbox is selected to indicate the product is manufactured in production
-  - the process plan is selected
-  - the default storage bin that is used for the product is defined in the [_Manufacturing_](../master-data-management/master-data.md#product) tab
-- based on [cost calculations](transactions.md#calculate-standard-costs), a "theoretical" standard cost can be determined for the finished product
-- a safety stock level is determined and entered for the product
+    - Raw material used in production:
+        - The **production** checkbox is selected to indicate that the product is used for production.
+        - The process plan is selected.
+        - The default storage bin used to store the raw materials used (P-),  is defined in the [manufacturing](../master-data-management/master-data.md#manufacturing) tab.
 
-Any semi finished products are created directly in the process plan by copying the information of a raw material product used in the operation. Once created, the default storage bin is defined in the [_Manufacturing_](../master-data-management/master-data.md#product) tab.
+    - Any **semi finished products** are created directly in the process plan by copying the information of a raw material product used in the operation using the [Create Product Copy](./setup.md#io-products) button. Once created, the default storage bin is defined in the [manufacturing](../master-data-management/master-data.md#manufacturing) tab.
 
-!!! info
-    For more information about the configuration of products, please refer to the [_Product_](../master-data-management/master-data.md#product) section.
+    - Finished products manufactured in production:
+        - The **production** checkbox is selected to indicate the product is manufactured in production.
+        - The process plan is selected.
+        - The default storage bin that is used for the finished products (P+),  is defined in the [manufacturing](../master-data-management/master-data.md#manufacturing) tab.
+        - Based on [cost calculations](transactions.md#calculate-standard-costs), a **theoretical** standard cost can be determined for the finished product.
+        - A safety stock level is determined and entered for the product.
 
-Also, Business Partners are configured for production:
 
-In the Employee tab, any employees that are involved in the production process have the operator checkbox selected.
+    !!! info
+        For more information about the configuration of products, please refer to the [Product](../master-data-management/master-data.md#product) section.
 
-Likewise, the [_Salary category_](../master-data-management/master-data.md#salary-category) configured for employees is very important since they are included in the final cost calculations.
 
-!!! info
-    For more information about the configuration of business partners, please refer to the [_Business Partner_](../master-data-management/master-data.md#business-partner) section.
+2. Also, Business Partners are configured for production:
 
-Work Efforts can be posted to the [_General Ledger Journal_](../financial-management/accounting/transactions.md#gl-journal). In order to facilitate the posting, the **MaterialMgmtProductionTransaction** table is activated in the [_Active Tables_](../financial-management/accounting/setup.md#glconfig) tab of the General Ledger configuration.
+    - In the Employee tab, any employees that are involved in the production process have the **operator** checkbox selected.
+    - The [Salary category](../master-data-management/master-data.md#salary-category) configured for employees is very important since they are included in the final cost calculations.
 
-#### **Execution**
+    !!! info
+        For more information about the configuration of business partners, please refer to the [Business Partner](../master-data-management/master-data.md#business-partner) section.
 
-Sales staff enters Sales Order for the product with the quantity required and the date by when it needs to be delivered. If the product is not in stock, it needs to be produced.
+3. Work Efforts can be posted to the [General Ledger Journal](../financial-management/accounting/transactions.md#gl-journal). In order to facilitate the posting, the **MaterialMgmtProductionTransaction** table is activated in the [Active Tables](../financial-management/accounting/setup.md#glconfig) tab of the General Ledger configuration.
 
-Also, if the stock level is below the safety stock level, products have to be produced.
+## Execution
 
-The information about the demand from sales orders and safety stock is handled in 2 ways:
+1. Sales staff enters **Sales Order** for the product with the quantity required and the date by when it needs to be delivered. If the product is not in stock, it needs to be produced. Also, if the stock level is below the safety stock level, products have to be produced.
 
-- automatically in MRP
-- manually by a production manager
+    The information about the demand from sales orders and safety stock is handled in 2 ways:
 
-Ideally, the information is handled by MRP. If not, a production manager reviews if production of the product is required by reviewing the total demand:
+    - Automatically in [Material Requirement Planning (MRP)](../material-requirement-planning/getting-started.md).
+    - Manually by a production manager.
 
-- the outstanding sales orders
-- the safety stock level
+2. Ideally, the information is handled by MRP. If not, a production manager reviews if production of the product is required by reviewing the total demand:
 
-and compare it with the total supply:
+    - The outstanding sales orders
+    - The safety stock level
 
-- the stock level
-- scheduled Work Requirements
+    and compare it with the total supply:
 
-If the demand is higher than the supply, or the dates of scheduled Work Requirements are not matching the dates of the outstanding sales orders, the product needs to be produced and a production manager executes:
+    - The stock level.
+    - Scheduled Work Requirements.
 
-- review of the stock of the raw material. If needed, the raw material will be requested and used in the [_procurement management_](../procurement-management/transactions.md) process.
-- entry of the Work Requirement for the required quantity with the required quantity and the planned date
-- generate Work Efforts from the Work Requirement.
+3. If the demand is higher than the supply, or the dates of scheduled Work Requirements are not matching the dates of the outstanding sales orders, the product needs to be produced and a production manager executes:
 
-The staff responsible for executing the production can see on the Production Run Status Report what production has to be executed.
+    - Review of the stock of the raw material. If needed, the raw material will be requested and used in the [Procurement Management](../procurement-management/getting-started.md) process.
+    - Entry of the **Work Requirement** for the required quantity with the required quantity and the planned date.
+    - Generate **Work Efforts** from the Work Requirement.
 
-At the end of each shift, the production managers enter the information of what is produced in the [_Production Run_](transactions.md#production-run_1) screen.
+4. The staff responsible for executing the production can see on the **Production Run Status Report** what production has to be executed.
+
+5. At the end of each shift, the production managers enter the information of what is produced in the [Production Run](transactions.md#production-run-1) windows.
 
 ## Relationship with other areas
 
 Production Management interacts with the following modules:
 
-- [_Procurement Management_](../procurement-management/getting-started.md): raw material required for use in production is bought using the Procure to Pay process
-- [_Sales Management_](../sales-management/getting-started.md): demand for the products that are produced are generated through the Order to Cash process
-- [_Warehouse Management_](../warehouse-management/getting-started.md):
-    - raw material is taken from the warehouse to be used in production
-    - end products that come out of production are put into stock
-- [_MRP_](../material-requirement-planning/getting-started.md): Work Requirements can be a result of MRP
-- [_Financial Management_](../financial-management/getting-started.md): Cost related to Production is calculated for finance.
+- [Procurement Management](../procurement-management/getting-started.md): raw material required for use in production is bought using the Procure to Pay process.
+- [Sales Management](../sales-management/getting-started.md): demand for the products that are produced are generated through the Order to Cash process.
+- [Warehouse Management](../warehouse-management/getting-started.md):
+    - Raw material is taken from the warehouse to be used in production
+    - End products that come out of production are put into stock
+- [Material Requirement Planning](../material-requirement-planning/getting-started.md): Work Requirements can be a result of MRP
+- [Financial Management](../financial-management/getting-started.md): Cost related to Production is calculated for finance.
+
+---
+
+This work is a derivative of ["Production Management"](http://wiki.openbravo.com/wiki/Production_Management){target="\_blank"} by [Openbravo Wiki](http://wiki.openbravo.com/wiki/Welcome_to_Openbravo){target="\_blank"}, used under [CC BY-SA 2.5 ES](https://creativecommons.org/licenses/by-sa/2.5/es/){target="\_blank"}. This work is licensed under [CC BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/){target="\_blank"} by [Etendo](https://etendo.software){target="\_blank"}.

--- a/docs/user-guide/etendo-classic/basic-features/production-management/setup.md
+++ b/docs/user-guide/etendo-classic/basic-features/production-management/setup.md
@@ -633,3 +633,8 @@ Here, the user can define general maintenance tasks to be used in production.
 All maintenance tasks that are scheduled for the machines in production are entered in this screen:
 
 ![](../../../../assets/drive/YtlJL911EsQf5c-i8qMbFGpGQQFQHr1qO_V-VuJ1MByU4_t0QH3qhOFPgsZWLSareLUEaU7DvfLB8wHCb_ftn4_eDL28TUcbiGExcqGb6fYropD0oB6PVqqrn5jtPdZ7uSeiCA3AS8FUbkiVADrH9Q29ErN4lAKd-cHGjIzocw0nku0vkHPF60nbyKKZPg.png)
+
+
+---
+
+This work is a derivative of ["Production Management"](http://wiki.openbravo.com/wiki/Production_Management){target="\_blank"} by [Openbravo Wiki](http://wiki.openbravo.com/wiki/Welcome_to_Openbravo){target="\_blank"}, used under [CC BY-SA 2.5 ES](https://creativecommons.org/licenses/by-sa/2.5/es/){target="\_blank"}. This work is licensed under [CC BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/){target="\_blank"} by [Etendo](https://etendo.software){target="\_blank"}.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,7 +168,7 @@ extra:
       - accept
       - manage 
     
-copyright: Copyright &copy; 2021 - 2025 Etendo Software
+copyright: Copyright &copy; 2021 - 2025 Futit Services S.L.
 
 nav:
   - Home : index.md


### PR DESCRIPTION
**Feedback**: In the configuration section, there is a bullet list that is a little mess up. It states that you should configure some products, but then it states that there is a production plan, then talks about some product configurations, and finally that cost will be automatically calculated? The info is not wrong, but is not properly ordered and makes a difficult read. Also if you go to the product article, the production configuration is called manufacturing.

Link to Wiki: [Production Management - Getting Started](https://docs.etendo.software/latest/user-guide/etendo-classic/basic-features/production-management/getting-started/)

**Changes:**

![image](https://github.com/user-attachments/assets/5ec0bdfd-21cc-4a41-9a24-9e33a53a5f87)
![image](https://github.com/user-attachments/assets/46f6176f-ac56-43da-b3ad-5db279b23c71)
