### PR TITLE
Update live-builds test environment URLs and add icons :memo:

### DIFF
--- a/docs/es/live-builds/overview.md
+++ b/docs/es/live-builds/overview.md
@@ -24,9 +24,10 @@ Esta página proporciona acceso rápido a entornos de prueba en vivo de Etendo q
 
     ---
 
-    [Etendo 24 + Bundles](https://demo24.bundles.etendo.cloud/etendo/security/Login){ target="blank"}<br>
-    [Etendo 25+ Bundles](https://demo25.bundles.etendo.cloud/etendo/security/Login){ target="blank"}<br>
-    [:material-new-box: Etendo 25+ Bundles + Nueva UI](https://demo25.bundles.newui.etendo.cloud){ target="blank"}
+    [Etendo 26 + Bundles (New UI)](https://demo.etendo.cloud){ target="blank"}<br>
+    [Etendo 26 + Bundles (Classic UI)](https://demo.etendo.cloud/etendo){ target="blank"}<br><br>
+    [Etendo 25 + Bundles (New UI)](https://demo25.bundles.etendo.cloud){ target="blank"}<br>
+    [Etendo 25 + Bundles (Classic UI)](https://demo25.bundles.etendo.cloud/etendo){ target="blank"}
 
 -   :material-test-tube:{ .lg .middle } **Etendo**
 
@@ -34,8 +35,9 @@ Esta página proporciona acceso rápido a entornos de prueba en vivo de Etendo q
 
     ---
 
-    [Etendo 24](https://demo24.etendo.cloud/etendo/security/Login){ target="blank"} <br>
-    [Etendo 25](https://demo25.etendo.cloud/etendo/security/Login){ target="blank"} 
+    [Etendo 26 (New UI)](https://demo26.etendo.cloud){ target="blank"}<br>
+    [Etendo 26 (Classic UI)](https://demo26.etendo.cloud/etendo){ target="blank"}<br><br>
+    [Etendo 25](https://demo25.etendo.cloud){ target="blank"}
 
 </div>
 
@@ -43,10 +45,12 @@ Esta página proporciona acceso rápido a entornos de prueba en vivo de Etendo q
 
 !!! tip "Credenciales"
     Las credenciales de acceso por defecto son: <br> 
-    **Nombre usuario:** admin <br>
+    **Nombre de usuario:** admin <br>
     **Contraseña:** admin <br>
 
 !!! note "Estas compilaciones en vivo se actualizan y se restablecen todos los días a las 9:00 PM UTC."
     
 
 !!! warning "Si sus requisitos de prueba incluyen la base de datos Oracle, póngase en contacto con nuestro [equipo de soporte](../help-and-support/support-service.md) para obtener más ayuda y acceso a entornos basados en Oracle."
+
+---

--- a/docs/live-builds/overview.md
+++ b/docs/live-builds/overview.md
@@ -24,9 +24,10 @@ This page provides quick access to Etendo live test environments that are always
 
     ---
 
-    [Etendo 24 + Bundles](https://demo24.bundles.etendo.cloud/etendo/security/Login){ target="blank"}<br>
-    [Etendo 25 + Bundles](https://demo.etendo.cloud/etendo/security/Login){ target="blank"}<br>
-    [:material-new-box: Etendo 25 + Bundles + New UI](https://demo25.bundles.newui.etendo.cloud){ target="blank"}
+    [Etendo 26 + Bundles (New UI)](https://demo.etendo.cloud){ target="blank"}<br>
+    [Etendo 26 + Bundles (Classic UI)](https://demo.etendo.cloud/etendo){ target="blank"}<br><br>
+    [Etendo 25 + Bundles (New UI)](https://demo25.bundles.etendo.cloud){ target="blank"}<br>
+    [Etendo 25 + Bundles (Classic UI)](https://demo25.bundles.etendo.cloud/etendo){ target="blank"}
 
 -   :material-test-tube:{ .lg .middle } **Etendo**
 
@@ -34,8 +35,9 @@ This page provides quick access to Etendo live test environments that are always
 
     ---
 
-    [Etendo 24](https://demo24.etendo.cloud/etendo/security/Login){ target="blank"} <br>
-    [Etendo 25](https://demo25.etendo.cloud/etendo/security/Login){ target="blank"} 
+    [Etendo 26 (New UI)](https://demo26.etendo.cloud){ target="blank"}<br>
+    [Etendo 26 (Classic UI)](https://demo26.etendo.cloud/etendo){ target="blank"}<br><br>
+    [Etendo 25](https://demo25.etendo.cloud){ target="blank"}
 
 </div>
 


### PR DESCRIPTION
- Remove decommissioned Etendo 24 environments
- Add Etendo 26 + Bundles (new UI + Classic UI) at demo.etendo.cloud
- Add Etendo 25 + Bundles (new UI + Classic UI) at demo25.bundles.etendo.cloud
- Add Etendo 26 standalone (new UI + Classic UI) at demo26.etendo.cloud
- Add Etendo 25 standalone at demo25.etendo.cloud
- Add material icons: new-box (v26), monitor (Classic UI), history (v25)