### PR TITLE
Feature ETP-2129: Improve prod movement report doc

### DIFF
--- a/docs/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/pareto-product-report.md
+++ b/docs/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/pareto-product-report.md
@@ -11,7 +11,7 @@ title: Pareto Product Report
 **Pareto Product Report** distributes products into three classes (A, B or C) according to the cost value that each product inventory has in the warehouse. Based on this classification the frequency of counting cycle can be decided (e.g. A products are counted weekly, B products monthly and C products yearly).
 
 Following distribution is used: A products represent 80% value of the warehouse, B - 15% and C- 5%.
-> 
+
 !!! info
     The classification is based on the cost of the product. That is why it is needed to have a Costing Rule validated and the Material Transaction costs of the product calculated up to date.
 

--- a/docs/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/product-operations.md
+++ b/docs/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/product-operations.md
@@ -10,11 +10,11 @@ title: Product Operations
     To be able to include this functionality, the Warehouse Extensions Bundle must be installed. To do that, follow the instructions from the marketplace: [Warehouse Extensions Bundle](https://marketplace.etendo.cloud/#/product-details?module=EFDA39668E2E4DF2824FFF0A905E6A95){target="_blank"}. For more information about the available versions, core compatibility and new features, visit [Warehouse Extensions - Release notes](../../../../../whats-new/release-notes/etendo-classic/bundles/warehouse-extensions/release-notes.md).
 
 
-This functionality **centralizes of all the transactions** associated with the product selected allowing the visualization of every movement and actions such as goods shipment/receip line, tax original cost, unit cost, storage bin and many other related actions to the products. 
+This functionality **centralizes all the transactions** associated with the selected product, allowing the visualization of every movement and actions such as goods shipment/receipt line, tax original cost, unit cost, storage bin and many other product-related actions.
 
 This centralization facilitates the analysis and a complete understanding of the product operation performance.
 
-![alt text](../../../../../assets/user-guide/etendo-classic/basic-features/warehouse-management/product-operations-0.png)
+![Product Operations window](../../../../../assets/user-guide/etendo-classic/basic-features/warehouse-management/product-operations-0.png)
 
 ---
 

--- a/docs/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/stock-history.md
+++ b/docs/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/stock-history.md
@@ -29,7 +29,7 @@ The window shows the following fields from which the user is able to filter and 
 - Warehouse
 - Storage Bin
 - Quantity on hand
-- Reserved QtY
+- Reserved Qty
 - Allocated Quantity
 - Quantity in draft transaction
  

--- a/docs/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/valued-stock-report.md
+++ b/docs/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/valued-stock-report.md
@@ -14,7 +14,7 @@ The cost is calculated as a sum of the cost of each material transaction of the 
 
 ### **Parameters Window**
 
-![Material Transaction Report](../../../../../assets/drive/1HGDsUBdSrfe3_Nzk_ojKq3Ck-aGvIAdx.png)
+![Valued Stock Report Parameters Window](../../../../../assets/drive/1HGDsUBdSrfe3_Nzk_ojKq3Ck-aGvIAdx.png)
 
 
 
@@ -30,16 +30,16 @@ The cost is calculated as a sum of the cost of each material transaction of the 
 
 ### **Output Window** 
 
-![Material Transaction Report](../../../../../assets/drive/1btCDeLvHaczMWt9lE05E0J8RFjePTZFM.png)
+![Valued Stock Report Output](../../../../../assets/drive/1btCDeLvHaczMWt9lE05E0J8RFjePTZFM.png)
 
 
 -   **Product**: Name of the Product.
 -   **Quantity**: Stock of the Product on the selected date.
 -   **Unit** : Unit in which the stock is measured.
--   **Unit Cost**: Cost of each particular unit. Ii is the result of dividing the Valuation between the Stock.
+-   **Unit Cost**: Cost of each particular unit. It is the result of dividing the Valuation between the Stock.
 -   **Valuation**: Valuation of the Stock. It is calculated by adding up all the valuations of each transaction that has happened in the Warehouse.
--   **Actual Average/Standard Algorithm Cost**: Current Average/Standard Cost, the latest calculation of it's value.
--   **Actual Average/Standard Algorithm Valuation**: Valuation of the Stock based on the Actual Average/Standard Cost. Ii is the result of multiplying the Stock by the Actual Cost.
+-   **Actual Average/Standard Algorithm Cost**: Current Average/Standard Cost, the latest calculation of its value.
+-   **Actual Average/Standard Algorithm Valuation**: Valuation of the Stock based on the Actual Average/Standard Cost. It is the result of multiplying the Stock by the Actual Cost.
 
 ### **Persisted Information**
 
@@ -47,12 +47,12 @@ This step is not necessary in order to launch the Report. However, if there are 
 
 It is possible to aggregate information that allows for faster queries. This information is aggregated for each Closed Accounting Period, that means that accounting periods must be defined and, at least some of them, must be in a *Closed* or *Permanently Closed* Status. 
 
-The information will persist until the first not closed Period. By doing so, it is possible to avoid looping through many records. However, no information will be aggregated after the first closed period and this can result in a non optimal performance of the report if it needs to retrieve plenty of information.
+The information will persist until the first not closed Period. By doing so, it is possible to avoid looping through many records. However, no information will be aggregated after the first closed period and this can result in a non-optimal performance of the report if it needs to retrieve plenty of information.
 
 !!! info
     In order to use this functionality it is necessary to schedule the Background Process named *Generate Aggregated Data Background*. This can be done through the *Process Request* Window.
 
-![Material Transaction Report](../../../../../assets/drive/1_mjP-Y6k-QGbCLm8FeIQI08YLJghMAfM.png)
+![Valued Stock Report Process Request](../../../../../assets/drive/1_mjP-Y6k-QGbCLm8FeIQI08YLJghMAfM.png)
 
 !!! info
     It is recommended to schedule it daily, at a moment when the System does not have plenty of activity. It will aggregate data only when a new Period is Closed or Permanently Closed.


### PR DESCRIPTION
## Summary
- Fixed wrong image alt texts in `valued-stock-report.md` (screenshots were labelled "Material Transaction Report")
- Fixed grammar in `valued-stock-report.md`: `"Ii is"` → `"It is"` (×2), `"it's value"` → `"its value"`, `"non optimal"` → `"non-optimal"`
- Fixed grammar in `product-operations.md`: `"centralizes of all"` → `"centralizes all"`, `"receip line"` → `"receipt line"`, `"alt text"` → descriptive alt text
- Fixed typo in `stock-history.md`: `"Reserved QtY"` → `"Reserved Qty"`
- Removed stray empty blockquote (`>`) in `pareto-product-report.md`

## Test plan
- [ ] Verify all changed pages render correctly in MkDocs
- [ ] Confirm no new warnings in `mkdocs build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)