### PR TITLE
Feature ETP-2129: Improve prod movement report doc

### DIFF
--- a/docs/es/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/pareto-product-report.md
+++ b/docs/es/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/pareto-product-report.md
@@ -1,0 +1,49 @@
+---
+title: Informe Pareto de Productos
+---
+
+## Informe Pareto de Productos
+
+:material-menu: `Aplicación` > `Gestión de Almacén` > `Herramientas de análisis` > `Informe Pareto de Productos`
+
+### **Overview**
+
+**Informe Pareto de Productos** distribuye los productos en tres clases (A, B o C) según el valor del costo que tiene el inventario de cada producto en el almacén. En función de esta clasificación se puede decidir la frecuencia del ciclo de conteo (por ejemplo, los productos A se cuentan semanalmente, los B mensualmente y los C anualmente).
+
+Se utiliza la siguiente distribución: los productos A representan el 80% del valor del almacén, los B el 15% y los C el 5%.
+
+!!! info
+    La clasificación se basa en el costo del producto. Por eso es necesario tener una Regla de Costeo validada y los costos de las transacciones de material del producto calculados y actualizados.
+
+
+### **Parameters window**
+
+El campo **Moneda** define la moneda en la que se muestran todos los valores monetarios (como **Costo**, **Valor**) del informe. El campo toma por defecto la moneda del sistema.
+
+!!! warning
+    Tenga en cuenta que se debe especificar el **Ratio de conversión** a la **Moneda** del informe para que este funcione.
+
+El botón **Update ABC** completa el campo **ABC** (actualiza el valor si el registro existe o crea un nuevo registro en caso contrario) de la pestaña Org. Specific de la ventana **Producto** para las organizaciones de la salida del informe.
+
+### **Sample Report Output**
+
+![Material Transaction Report](../../../../../assets/drive/1DpBnQAG8Xyk9rM5xKhQvdKNt8p-bm4tj.png)
+
+
+Columnas a tener en cuenta:
+
+-   **Cantidad:** es el stock actual del producto (Quantity on Hand) en el almacén seleccionado.
+-   **Valor:** es la suma de todos los costos de las transacciones de material del producto.
+-   **Costo:** este costo se calcula como la relación entre el valor del producto y la cantidad del producto indicada arriba.
+-   **Porcentaje:** este porcentaje es la relación entre el valor del producto y el Valor Total del almacén (que es la suma de todas las líneas del informe).
+
+### **Persisted information**
+
+Se puede utilizar la información agregada calculada para el Valued Stock. Consulte la documentación del Valued Stock Report para obtener más detalles sobre cómo generar la información agregada.
+
+!!! note
+    Exactamente igual que en el Valued Stock Report, el Informe Pareto de Productos también se puede ejecutar sin datos agregados. Sin embargo, esta función es especialmente útil en entornos de alto volumen cuando se experimentan problemas de rendimiento al ejecutar el informe.
+
+---
+
+Este trabajo es una derivación de [Warehouse Management](http://wiki.openbravo.com/wiki/Warehouse_Management){target="\_blank"} por [Openbravo Wiki](http://wiki.openbravo.com/wiki/Welcome_to_Openbravo){target="\_blank"}, utilizado bajo [CC BY-SA 2.5 ES](https://creativecommons.org/licenses/by-sa/2.5/es/){target="\_blank"}. Este trabajo está licenciado bajo [CC BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/){target="\_blank"} por [Etendo](https://etendo.software){target="\_blank"}.

--- a/docs/es/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/product-operations.md
+++ b/docs/es/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/product-operations.md
@@ -1,0 +1,21 @@
+---
+title: Operaciones de Producto
+---
+
+## Operaciones de Producto
+
+:material-menu: `Aplicación` > `Gestión de Almacén` > `Herramientas de análisis` > `Operaciones de Producto`
+
+!!! info
+    Para poder incluir esta funcionalidad, el paquete Warehouse Extensions Bundle debe estar instalado. Para ello, siga las instrucciones del marketplace: [Warehouse Extensions Bundle](https://marketplace.etendo.cloud/#/product-details?module=EFDA39668E2E4DF2824FFF0A905E6A95){target="_blank"}. Para obtener más información sobre las versiones disponibles, la compatibilidad con core y las nuevas funcionalidades, visite [Warehouse Extensions - Release notes](../../../../../whats-new/release-notes/etendo-classic/bundles/warehouse-extensions/release-notes.md).
+
+
+Esta funcionalidad **centraliza todas las transacciones** asociadas al producto seleccionado, permitiendo la visualización de cada movimiento y de acciones como línea de envío/recepción de mercancías, coste original del impuesto, coste unitario, ubicación de almacén y muchas otras acciones relacionadas con el producto.
+
+Esta centralización facilita el análisis y una comprensión completa del rendimiento de las operaciones del producto.
+
+![Ventana de Operaciones de Producto](../../../../../assets/user-guide/etendo-classic/basic-features/warehouse-management/product-operations-0.png)
+
+---
+
+Este trabajo es un derivado de [Warehouse Management](http://wiki.openbravo.com/wiki/Warehouse_Management){target="\_blank"} de [Openbravo Wiki](http://wiki.openbravo.com/wiki/Welcome_to_Openbravo){target="\_blank"}, utilizado bajo [CC BY-SA 2.5 ES](https://creativecommons.org/licenses/by-sa/2.5/es/){target="\_blank"}. Este trabajo está licenciado bajo [CC BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/){target="\_blank"} por [Etendo](https://etendo.software){target="\_blank"}.

--- a/docs/es/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/stock-history.md
+++ b/docs/es/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/stock-history.md
@@ -1,0 +1,42 @@
+---
+title: Historial de existencias
+---
+
+## Historial de existencias
+
+:material-menu: `Aplicación` > `Gestión de Almacén` > `Herramientas de análisis` > `Historial de existencias`
+
+!!! info
+    Para poder incluir esta funcionalidad, debe instalarse el paquete Warehouse Extensions Bundle. Para ello, siga las instrucciones del marketplace: [Warehouse Extensions Bundle](https://marketplace.etendo.cloud/#/product-details?module=EFDA39668E2E4DF2824FFF0A905E6A95){target="_blank"}. Para obtener más información sobre las versiones disponibles, la compatibilidad con el core y las nuevas funcionalidades, visite [Warehouse Extensions - Release notes](../../../../../whats-new/release-notes/etendo-classic/bundles/warehouse-extensions/release-notes.md).
+ 
+
+Esta es una ventana de solo lectura en la que el usuario puede consultar el stock diario. Esta funcionalidad actualiza la información diaria recopilada por el proceso en segundo plano que se creó previamente para este propósito. 
+
+La ventana Historial de existencias se rellena únicamente mediante el proceso en segundo plano "Create Stock History". Puede programarse desde la ventana 'Request Processing', donde se puede asignar para qué rol y organización se ejecuta, y la periodicidad con la que se ejecuta.
+
+!!! info
+    Consulte la documentación técnica sobre Historial de existencias para ampliar el proceso y calcular los registros del historial diario de existencias. 
+
+
+No se mostrarán datos en la ventana hasta que se apliquen filtros de búsqueda. Una vez aplicados los filtros, haga clic en el botón de la derecha para completar el proceso. 
+
+![](../../../../../assets/drive/10C8VIJpu2FJkojmrZ8aKCZMZo0D0OpMJ.png)
+
+La ventana muestra los siguientes campos a partir de los cuales el usuario puede filtrar y obtener los datos necesarios: 
+- Fecha de stock 
+- Producto
+- Valor del conjunto de atributos
+- Almacén
+- Ubicación de almacenamiento
+- Cantidad en stock
+- Cantidad reservada
+- Cantidad asignada
+- Cantidad en transacción en borrador
+ 
+![](../../../../../assets/drive/1MhFI0Ii9bhm8EBBK-UalKWK90_-Gkm_G.png)
+
+Esta funcionalidad incluye un proceso para cerrar el stock y guardar la información histórica.
+
+---
+
+Este trabajo es un derivado de [Warehouse Management](http://wiki.openbravo.com/wiki/Warehouse_Management){target="\_blank"} de [Openbravo Wiki](http://wiki.openbravo.com/wiki/Welcome_to_Openbravo){target="\_blank"}, utilizado bajo [CC BY-SA 2.5 ES](https://creativecommons.org/licenses/by-sa/2.5/es/){target="\_blank"}. Este trabajo está licenciado bajo [CC BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/){target="\_blank"} por [Etendo](https://etendo.software){target="\_blank"}.

--- a/docs/es/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/valued-stock-report.md
+++ b/docs/es/user-guide/etendo-classic/basic-features/warehouse-management/analysis-tools/valued-stock-report.md
@@ -1,0 +1,67 @@
+---
+title: Informe de Valuación de Existencias
+---
+
+## Informe de Valuación de Existencias
+
+:material-menu: `Aplicación` > `Gestión de Almacén` > `Herramientas de análisis` > `Informe de Valuación de Existencias`
+
+### **Overview**
+
+El Informe de Valuación de Existencias muestra el stock de un almacén concreto, así como el valor del stock.
+
+El coste se calcula como la suma del coste de cada transacción de material del producto en el almacén. El coste de las transacciones del producto se calcula mediante el proceso Costing Server.
+
+### **Parameters Window**
+
+![Valued Stock Report Parameters Window](../../../../../assets/drive/1HGDsUBdSrfe3_Nzk_ojKq3Ck-aGvIAdx.png)
+
+
+
+-   **Organización**: Este campo permite al usuario seleccionar entre organizaciones de tipo "Legal with Accounting" y "Generic".
+-   **Almacén**: Si la organización seleccionada es "Generic", entonces lista todos los almacenes que le pertenecen; en caso contrario, si la organización es "Legal with accounting", no se muestra ningún almacén para seleccionar.
+-   **Date**: El informe mostrará la información hasta la fecha seleccionada.
+-   **Consolidated Warehouse**: Si se marca, la información del stock se consolidará a nivel de organización; en caso contrario, la información se desglosará por almacén.
+-   **Categoría del Producto**: Permite mostrar información solo de la Categoría del Producto seleccionada.
+-   **Moneda**: Define la moneda en la que se muestran todos los valores monetarios del informe (como Coste, Valoración).
+
+!!! warning
+    Tenga en cuenta que para que el informe funcione debe especificarse el tipo de cambio a la moneda del informe.
+
+### **Output Window** 
+
+![Valued Stock Report Output](../../../../../assets/drive/1btCDeLvHaczMWt9lE05E0J8RFjePTZFM.png)
+
+
+-   **Producto**: Nombre del producto.
+-   **Cantidad**: Stock del producto en la fecha seleccionada.
+-   **Unidad de medida** : Unidad en la que se mide el stock.
+-   **Coste Unitario**: Coste de cada unidad concreta. Es el resultado de dividir la Valoración entre el stock.
+-   **Valoración**: Valoración del stock. Se calcula sumando todas las valoraciones de cada transacción que ha tenido lugar en el almacén.
+-   **Actual Average/Standard Algorithm Cost**: Coste medio/estándar actual, el cálculo más reciente de su valor.
+-   **Actual Average/Standard Algorithm Valuation**: Valoración del stock basada en el Coste medio/estándar actual. Es el resultado de multiplicar el stock por el coste actual.
+
+### **Persisted Information**
+
+Este paso no es necesario para lanzar el informe. Sin embargo, si existen problemas de rendimiento, esto puede ayudar a mejorar considerablemente el rendimiento del informe.
+
+Es posible agregar información que permite realizar consultas más rápidas. Esta información se agrega para cada período contable cerrado, lo que significa que los períodos contables deben estar definidos y, al menos algunos de ellos, deben estar en un estado *Cerrado* o *Cerrado permanentemente*.
+
+La información persistirá hasta el primer período no cerrado. De este modo, es posible evitar recorrer muchos registros. Sin embargo, no se agregará información después del primer período cerrado y esto puede provocar un rendimiento no óptimo del informe si necesita recuperar mucha información.
+
+!!! info
+    Para usar esta funcionalidad es necesario programar el proceso en segundo plano llamado *Generate Aggregated Data Background*. Esto puede hacerse a través de la ventana *Process Request*.
+
+![Valued Stock Report Process Request](../../../../../assets/drive/1_mjP-Y6k-QGbCLm8FeIQI08YLJghMAfM.png)
+
+!!! info
+    Se recomienda programarlo diariamente, en un momento en que el sistema no tenga mucha actividad. Agregará datos solo cuando un nuevo período se cierre o se cierre permanentemente.
+
+
+### **Limitations**
+
+Al agregar la información por cada período cerrado, no es posible conservar la fecha de cada transacción. Por tanto, cuando el informe se lance para una moneda diferente, toda esa información se convertirá en la fecha de cierre del período. Esto puede provocar pequeñas discrepancias con la versión anterior debido a conversiones entre monedas en fechas diferentes.
+
+---
+
+This work is a derivative of [Warehouse Management](http://wiki.openbravo.com/wiki/Warehouse_Management){target="\_blank"} by [Openbravo Wiki](http://wiki.openbravo.com/wiki/Welcome_to_Openbravo){target="\_blank"}, used under [CC BY-SA 2.5 ES](https://creativecommons.org/licenses/by-sa/2.5/es/){target="\_blank"}. This work is licensed under [CC BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/){target="\_blank"} by [Etendo](https://etendo.software){target="\_blank"}.


### PR DESCRIPTION
## Summary
- Fixed wrong image alt texts in `valued-stock-report.md` (screenshots were labelled "Material Transaction Report")
- Fixed grammar in `valued-stock-report.md`: `"Ii is"` → `"It is"` (×2), `"it's value"` → `"its value"`, `"non optimal"` → `"non-optimal"`
- Fixed grammar in `product-operations.md`: `"centralizes of all"` → `"centralizes all"`, `"receip line"` → `"receipt line"`, `"alt text"` → descriptive alt text
- Fixed typo in `stock-history.md`: `"Reserved QtY"` → `"Reserved Qty"`
- Removed stray empty blockquote (`>`) in `pareto-product-report.md`
- Added ES translations for analysis tools sub-pages

## Test plan
- [ ] Verify all changed pages render correctly in MkDocs
- [ ] Confirm no new warnings in `mkdocs build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)